### PR TITLE
Removing UIWebView support from this library, since Apple is now warn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WebViewJavascriptBridge
 
 [![Circle CI](https://img.shields.io/circleci/project/github/marcuswestin/WebViewJavascriptBridge.svg)](https://circleci.com/gh/marcuswestin/WebViewJavascriptBridge)
 
-An iOS/OSX bridge for sending messages between Obj-C and JavaScript in WKWebViews, UIWebViews & WebViews.
+An iOS/OSX bridge for sending messages between Obj-C and JavaScript in WKWebViews & WebViews.
 
 Migration Guide
 ---------------
@@ -37,7 +37,7 @@ Installation (iOS & OSX)
 Add this to your [podfile](https://guides.cocoapods.org/using/getting-started.html) and run `pod install` to install:
 
 ```ruby
-pod 'WebViewJavascriptBridge', '~> 6.0'
+pod 'WebViewJavascriptBridge', '~> 7.0'
 ```
 
 ### Manual installation
@@ -68,7 +68,7 @@ Usage
 @property WebViewJavascriptBridge* bridge;
 ```
 
-2) Instantiate WebViewJavascriptBridge with a WKWebView, UIWebView (iOS) or WebView (OSX):
+2) Instantiate WebViewJavascriptBridge with a WKWebView (iOS) or WebView (OSX):
 
 ```objc
 self.bridge = [WebViewJavascriptBridge bridgeForWebView:webView];

--- a/Tests/WebViewJavascriptBridge.xcodeproj/project.pbxproj
+++ b/Tests/WebViewJavascriptBridge.xcodeproj/project.pbxproj
@@ -80,8 +80,8 @@
 			isa = PBXGroup;
 			children = (
 				2C3E7C5B1C5A928700A1E322 /* WebViewJavascriptBridge.h */,
-				2C3E7C5C1C5A928700A1E322 /* WebViewJavascriptBridge.m */,
 				2C3E7C5D1C5A928700A1E322 /* WebViewJavascriptBridge_JS.h */,
+				2C3E7C5C1C5A928700A1E322 /* WebViewJavascriptBridge.m */,
 				2C3E7C5E1C5A928700A1E322 /* WebViewJavascriptBridge_JS.m */,
 				2C3E7C5F1C5A928700A1E322 /* WebViewJavascriptBridgeBase.h */,
 				2C3E7C601C5A928700A1E322 /* WebViewJavascriptBridgeBase.m */,
@@ -223,6 +223,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
+++ b/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
@@ -15,12 +15,11 @@ static NSString *const echoHandler = @"echoHandler";
 
 @interface BridgeTests : XCTestCase
 @end
-@interface TestWebPageLoadDelegate : NSObject<UIWebViewDelegate, WKNavigationDelegate>
+@interface TestWebPageLoadDelegate : NSObject<WKNavigationDelegate>
 @property XCTestExpectation* expectation;
 @end
 
 @implementation BridgeTests {
-    UIWebView *_uiWebView;
     WKWebView *_wkWebView;
     NSMutableArray* _retains;
 }
@@ -31,9 +30,6 @@ static NSString *const echoHandler = @"echoHandler";
     UIViewController *rootVC = [[(AppDelegate *)[[UIApplication sharedApplication] delegate] window] rootViewController];
     CGRect frame = rootVC.view.bounds;
     frame.size.height /= 2;
-    _uiWebView = [[UIWebView alloc] initWithFrame:frame];
-    _uiWebView.backgroundColor = [UIColor blueColor];
-    [rootVC.view addSubview:_uiWebView];
     frame.origin.y += frame.size.height;
     _wkWebView = [[WKWebView alloc] initWithFrame:frame];
     _wkWebView.backgroundColor = [UIColor redColor];
@@ -44,7 +40,6 @@ static NSString *const echoHandler = @"echoHandler";
 
 - (void)tearDown {
     [super tearDown];
-    [_uiWebView removeFromSuperview];
     [_wkWebView removeFromSuperview];
 }
 
@@ -56,13 +51,12 @@ static NSString *const echoHandler = @"echoHandler";
 
 static void loadEchoSample(id webView) {
     NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"echo" withExtension:@"html"]];
-    [(UIWebView*)webView loadRequest:request];
+    [(WKWebView*)webView loadRequest:request];
 }
 
 const NSTimeInterval timeoutSec = 5;
 
 - (void)testEchoHandler {
-    [self classSpecificTestEchoHandler:_uiWebView];
     [self classSpecificTestEchoHandler:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
@@ -79,7 +73,6 @@ const NSTimeInterval timeoutSec = 5;
 }
 
 - (void)testEchoHandlerAfterSetup {
-    [self classSpecificTestEchoHandlerAfterSetup:_uiWebView];
     [self classSpecificTestEchoHandlerAfterSetup:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
@@ -97,7 +90,6 @@ const NSTimeInterval timeoutSec = 5;
 }
 
 - (void)testObjectEncoding {
-    [self classSpecificTestObjectEncoding:_uiWebView];
     [self classSpecificTestObjectEncoding:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
@@ -121,7 +113,6 @@ const NSTimeInterval timeoutSec = 5;
 }
 
 - (void)testJavascriptReceiveResponse {
-    [self classSpecificTestJavascriptReceiveResponse:_uiWebView];
     [self classSpecificTestJavascriptReceiveResponse:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
@@ -139,7 +130,6 @@ const NSTimeInterval timeoutSec = 5;
 }
 
 - (void)testJavascriptReceiveResponseWithoutSafetyTimeout {
-    [self classSpecificTestJavascriptReceiveResponseWithoutSafetyTimeout:_uiWebView];
     [self classSpecificTestJavascriptReceiveResponseWithoutSafetyTimeout:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
@@ -158,7 +148,6 @@ const NSTimeInterval timeoutSec = 5;
 }
 
 - (void)testWebpageLoad {
-    [self classSpecificTestWebpageLoad:_uiWebView];
     [self classSpecificTestWebpageLoad:_wkWebView];
     [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
 }
@@ -169,14 +158,11 @@ const NSTimeInterval timeoutSec = 5;
     [_retains addObject:delegate];
     [bridge setWebViewDelegate:delegate];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com"]];
-    [(UIWebView*)webView loadRequest:request];
+    [(WKWebView*)webView loadRequest:request];
 }
 @end
 
 @implementation TestWebPageLoadDelegate
-- (void)webViewDidFinishLoad:(UIWebView *)webView {
-    [self.expectation fulfill];
-}
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     [self.expectation fulfill];
 }

--- a/WebViewJavascriptBridge.podspec
+++ b/WebViewJavascriptBridge.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = 'WebViewJavascriptBridge'
-  s.version      = '6.0.3'
-  s.summary      = 'An iOS & OSX bridge for sending messages between Obj-C/Swift and JavaScript in WKWebViews, UIWebViews & WebViews.'
+  s.version      = '7.0.0'
+  s.summary      = 'An iOS & OSX bridge for sending messages between Obj-C/Swift and JavaScript in WKWebViews & WebViews.'
   s.homepage     = 'https://github.com/marcuswestin/WebViewJavascriptBridge'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { 'marcuswestin' => 'marcus.westin@gmail.com' }
   s.source       = { :git => 'https://github.com/marcuswestin/WebViewJavascriptBridge.git', :tag => 'v'+s.version.to_s }
-  s.platforms    = { :ios => "5.0", :osx => "" }
+  s.platforms    = { :ios => "8.0", :osx => "" }
   s.requires_arc = true
   
   s.ios.source_files         = 'WebViewJavascriptBridge/*.{h,m}'

--- a/WebViewJavascriptBridge/WebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridge.m
@@ -44,11 +44,18 @@
         return (WebViewJavascriptBridge*) [WKWebViewJavascriptBridge bridgeForWebView:webView];
     }
 #endif
+// NOTE: The following allows the old support for WebView (macOS 10.3-10.14 - now
+// deprecated), but not support for UIWebView (iOS 2.0-12.0 - now deprecated).
+// We do NOT want to support UIWebView on iOS, as Apple is warning developers of
+// UIWebView API usage when submitting an app to the AppStore.  The thought is that
+// this will soon be an error with iOS uploads in our near future.
+#if defined WVJB_PLATFORM_OSX
     if ([webView isKindOfClass:[WVJB_WEBVIEW_TYPE class]]) {
         WebViewJavascriptBridge* bridge = [[self alloc] init];
         [bridge _platformSpecificSetup:webView];
         return bridge;
     }
+#endif
     [NSException raise:@"BadWebViewType" format:@"Unknown web view type."];
     return nil;
 }


### PR DESCRIPTION
…ing developers of their usage of the UIWebView APIs when submitting apps to the App Store for review.   1. Removed UIWebView support and tests 2. Kept the WebView macOS support, as I don't think that has an issue yet. 3. Update the README.md to remove any UIWebView references. 4. Update the Podspec (version number, and description)

## Before your create your PR:

#### Please add tests for any new or changed functionality!

1. Edit `Tests/WebViewJavascriptBridgeTests/BridgeTests.m`
2. Create a new test which demostrates your changes.
3. Run `make test` and make sure your test is passing
4. That's it!

#### Thanks for improving WebViewJavascriptBridge!

Cheers,
@marcuswestin
